### PR TITLE
[FE] Implement snackbars for user feedback on errors/successes

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "formik": "^2.1.4",
     "mobx": "^5.15.4",
     "mobx-react": "^6.2.2",
+    "notistack": "^0.9.11",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-google-recaptcha": "^2.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,32 @@
 import React from 'react';
 import { Router } from '@reach/router';
 import { ThemeProvider } from '@material-ui/core/styles';
+import { Provider } from 'mobx-react';
+import { SnackbarProvider } from 'notistack';
 import { Database } from './database';
 import { IntakeFormPage } from './intake-form';
-import { SignIn } from './sign-in';
-import { Provider } from 'mobx-react';
-import { participantStore } from './injectables';
 import { NotFound } from './404-page';
+import { SignIn } from './sign-in';
+import { participantStore } from './injectables';
 import { theme } from './ui';
 import './App.css';
 
 const App = () => (
   <Provider participantStore={participantStore}>
     <ThemeProvider theme={theme}>
-      <Router>
-        <IntakeFormPage path="/" />
-        <SignIn path="sign-in" />
-        <Database path="database" />
-        <NotFound default />
-      </Router>
+      <SnackbarProvider
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+      >
+        <Router>
+          <IntakeFormPage path="/" />
+          <SignIn path="sign-in" />
+          <Database path="database" />
+          <NotFound default />
+        </Router>
+      </SnackbarProvider>
     </ThemeProvider>
   </Provider>
 );

--- a/src/intake-form/IntakeFormPage.js
+++ b/src/intake-form/IntakeFormPage.js
@@ -1,19 +1,34 @@
 import React from 'react';
-import { initialValues, IntakeForm, validationSchema } from './components';
 import { Formik } from 'formik';
+import { useSnackbar } from 'notistack';
+import {
+  IntakeForm,
+  validationSchema,
+  initialValues,
+} from './components';
 
-export const IntakeFormPage = () => (
-  <Formik
-    initialValues={initialValues}
-    validationSchema={validationSchema}
-    // placeholder onSubmit function
-    onSubmit={(values, { setSubmitting }) => {
-      setTimeout(() => {
-        console.log(JSON.stringify(values, null, 2));
-        setSubmitting(false);
-      }, 400);
-    }}
-  >
-    {(form) => <IntakeForm form={form} />}
-  </Formik>
-);
+export const IntakeFormPage = () => {
+  const { enqueueSnackbar } = useSnackbar();
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      // placeholder onSubmit function
+      onSubmit={(values, { setSubmitting }) => {
+        setTimeout(() => {
+          console.log(JSON.stringify(values, null, 2));
+          setSubmitting(false);
+          // TODO: display different snackbars depending on if submission was successful or not
+          // on success
+          enqueueSnackbar('Application successfully submitted.', {
+            variant: 'success',
+          });
+          // on fail
+          // enqueueSnackbar('There was a problem submitting your application.', { variant: 'error'})
+        }, 400);
+      }}
+    >
+      {(form) => <IntakeForm form={form} />}
+    </Formik>
+  );
+};

--- a/src/intake-form/components/FormStep.js
+++ b/src/intake-form/components/FormStep.js
@@ -8,7 +8,7 @@ export const FormStep = ({ form, step }) => {
   const { stepName, fields } = step;
 
   return (
-    <div className="fieldsContainer">
+    <div className="form-fieldsContainer">
       <Typography gutterBottom variant="h4">
         {stepName}
       </Typography>

--- a/src/intake-form/components/FormStepConfirmation.js
+++ b/src/intake-form/components/FormStepConfirmation.js
@@ -6,8 +6,8 @@ import './FormSteps.css';
 
 export const FormStepConfirmation = () => {
   return (
-    <div className="startPageContainer">
-      <div className="startPageContents">
+    <div className="form-pageContainer">
+      <div className="form-pageContents">
         <img
           className="logo"
           src={Logo}
@@ -22,7 +22,7 @@ export const FormStepConfirmation = () => {
         <Typography>
           You will be contacted soon for an interview.
         </Typography>
-        <div className="formTextContainer">
+        <div className="form-textContainer">
           <Typography variant="h5">Next steps</Typography>
           <Typography>
             In order to complete your application, Pathfinder requires

--- a/src/intake-form/components/FormStepStart.js
+++ b/src/intake-form/components/FormStepStart.js
@@ -5,8 +5,8 @@ import './FormSteps.css';
 
 export const FormStepStart = () => {
   return (
-    <div className="startPageContainer">
-      <div className="startPageContents">
+    <div className="form-pageContainer">
+      <div className="form-pageContents">
         <img
           className="logo"
           src={Logo}
@@ -15,7 +15,7 @@ export const FormStepStart = () => {
         <Typography gutterBottom align="center" variant="h4">
           Self-Enrollment System
         </Typography>
-        <div className="formTextContainer">
+        <div className="form-textContainer">
           <Typography
             gutterBottom
             align="center"

--- a/src/intake-form/components/FormSteps.css
+++ b/src/intake-form/components/FormSteps.css
@@ -1,13 +1,6 @@
-.fieldsContainer {
+.form-fieldsContainer {
   width: 100%;
   padding-top: 3em;
-}
-
-.formRow {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  margin-bottom: 1em;
 }
 
 .form-radioGroup {
@@ -22,20 +15,20 @@
   max-height: 10em;
 }
 
-.startPageContainer {
+.form-pageContainer {
   width: 100%;
   height: 100%;
 }
 
-.startPageContents {
+.form-pageContents {
   margin-top: 3em;
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-.formTextContainer {
-  margin: 3em 0;
+.form-textContainer {
+  margin: 1.5em 0;
   max-width: 70%;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3190,7 +3190,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.2, clsx@^1.0.4:
+clsx@^1.0.2, clsx@^1.0.4, clsx@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
@@ -7530,6 +7530,15 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+notistack@^0.9.11:
+  version "0.9.11"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.9.11.tgz#8ad61e5fc5bf29da3455fe3f2f809c1c421713e7"
+  integrity sha512-652+nnce7MC7eAgl6B4vPmo1wNOiFM9QBpIkH+b36rz0iMSjN/RTc9OL2xlRW4z/bzduLo5n9tnmXqD7MkAEJw==
+  dependencies:
+    clsx "^1.1.0"
+    hoist-non-react-statics "^3.3.0"
+    react-is "^16.8.6"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -9144,7 +9153,7 @@ react-google-recaptcha@^2.0.1:
     prop-types "^15.5.0"
     react-async-script "^1.1.1"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
In this PR:
- Added `notistack` dependency
- Added `SnackbarProvider` to `App`
- Added a few notifications to provide feedback when there is an error on the page or when form submission is successful

Note: The `SnackbarProvider` means we can use notifications like this anywhere in our app! 🎉 

*Error notification*
![Screen-Recording-2020-05-08-at-1 (1)](https://user-images.githubusercontent.com/24999233/81452949-2d769480-913d-11ea-9c2a-8496600eb2ae.gif)

*Success notification*
![Screen-Recording-2020-05-08-at-1](https://user-images.githubusercontent.com/24999233/81452946-2a7ba400-913d-11ea-9614-ccad376cee62.gif)


