### PR TITLE
[FE] Implement theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,8 @@
+html {
+  height: 100%;
+  width: 100%;
+}
+
 body {
   margin: 0;
   padding: 0;

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,25 @@
 import React from 'react';
 import { Router } from '@reach/router';
+import { ThemeProvider } from '@material-ui/core/styles';
 import { Database } from './database';
 import { IntakeFormPage } from './intake-form';
 import { SignIn } from './sign-in';
 import { Provider } from 'mobx-react';
 import { participantStore } from './injectables';
 import { NotFound } from './404-page';
+import { theme } from './ui';
 import './App.css';
 
 const App = () => (
   <Provider participantStore={participantStore}>
-    <Router>
-      <IntakeFormPage path="/" />
-      <SignIn path="sign-in" />
-      <Database path="database" />
-      <NotFound default />
-    </Router>
+    <ThemeProvider theme={theme}>
+      <Router>
+        <IntakeFormPage path="/" />
+        <SignIn path="sign-in" />
+        <Database path="database" />
+        <NotFound default />
+      </Router>
+    </ThemeProvider>
   </Provider>
 );
 

--- a/src/database/components/ListViewDrawer.js
+++ b/src/database/components/ListViewDrawer.js
@@ -60,7 +60,7 @@ export const ListViewDrawer = (props) => {
         <Divider />
         <ListItem button key="New Applications" onClick={handleClick}>
           <ListItemIcon>
-            <Badge badgeContent={numNew} color="secondary" overlap="circle">
+            <Badge badgeContent={numNew} color="error" overlap="circle">
               <Inbox />
             </Badge>
           </ListItemIcon>

--- a/src/intake-form/components/IntakeForm.js
+++ b/src/intake-form/components/IntakeForm.js
@@ -205,13 +205,13 @@ export const IntakeForm = (props) => {
             className="captcha"
           >
             This site is protected by reCAPTCHA and the Google{' '}
-            <a href="https://policies.google.com/privacy">
+            <Link href="https://policies.google.com/privacy">
               Privacy Policy
-            </a>{' '}
+            </Link>{' '}
             and{' '}
-            <a href="https://policies.google.com/terms">
+            <Link href="https://policies.google.com/terms">
               Terms of Service
-            </a>{' '}
+            </Link>{' '}
             apply.
           </Typography>
         </div>

--- a/src/sign-in/SignIn.css
+++ b/src/sign-in/SignIn.css
@@ -1,0 +1,4 @@
+.sign-in-container {
+  height: 100vh;
+  width: 100%;
+}

--- a/src/sign-in/SignIn.js
+++ b/src/sign-in/SignIn.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import LogIn from './components/Login';
-import NavBar from './components/NavBar';
+import { LogIn, NavBar } from './components';
+import './SignIn.css';
+
 
 // container that holds all sign in page UI objects
 export const SignIn = () => (
-  <>
+  <div className='sign-in-container'>
     <NavBar />
     <LogIn />
-  </>
+  </div>
 );

--- a/src/sign-in/components/Login.css
+++ b/src/sign-in/components/Login.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin: 3em;
 }
 
 .maxWidth {

--- a/src/sign-in/components/Login.js
+++ b/src/sign-in/components/Login.js
@@ -7,11 +7,10 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Link from '@material-ui/core/Link';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import './Login.css';
 
-class LogIn extends Component {
+export class LogIn extends Component {
   constructor(props) {
     super(props);
     this.authService = service.getAuthentication();
@@ -56,28 +55,15 @@ class LogIn extends Component {
     this.setState(newState);
   }
 
-  useStyles = makeStyles((theme) => ({
-    paper: {
-      marginTop: theme.spacing(8),
-    },
-    form: {
-      marginTop: theme.spacing(1),
-    },
-    submit: {
-      margin: theme.spacing(3, 0, 2),
-    },
-  }));
-
   render() {
-    const classes = this.useStyles;
     return (
       <Container component="main" maxWidth="xs">
-        <div className={`${classes.paper} paperStyle`}>
-          <Typography component="h1" variant="h5">
+        <div className={`paperStyle`}>
+          <Typography variant="h5">
             PYCS Staff Login Portal
           </Typography>
           <form
-            className={`${classes.form} maxWidth`}
+            className={`maxWidth`}
             noValidate
             onSubmit={this.handleLogin}
           >
@@ -117,7 +103,6 @@ class LogIn extends Component {
               variant="contained"
               color="primary"
               onClick={this.handleLogin}
-              className={classes.submit}
             >
               Sign In
             </Button>
@@ -134,5 +119,3 @@ class LogIn extends Component {
     );
   }
 }
-
-export default LogIn;

--- a/src/sign-in/components/NavBar.js
+++ b/src/sign-in/components/NavBar.js
@@ -3,13 +3,13 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 
-const NavBar = () => {
+export const NavBar = () => {
   const title = "Pathfinder Youth Centre Society Database Application"
   return (
     <>
       <AppBar position="static">
         <Toolbar>
-          <Typography variant="title" color="inherit">
+          <Typography color="inherit">
             {title}
           </Typography>
         </Toolbar>
@@ -17,5 +17,3 @@ const NavBar = () => {
     </>
   )
 }
-
-export default NavBar;

--- a/src/sign-in/components/index.js
+++ b/src/sign-in/components/index.js
@@ -1,0 +1,2 @@
+export * from './Login';
+export * from './NavBar';

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,0 +1,1 @@
+export * from './theme';

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -1,0 +1,22 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+const pathfinderDarkGreen = {
+  light: '#37834f',
+  main: '#056524',
+  dark: '#034619',
+  contrastText: '#fff'
+}
+
+const pathfinderLightGreen = {
+  light: '#64893c',
+  main: '#8FC456',
+  dark: '#a5cf77',
+  contrastText: '#fff'
+}
+
+export const theme = createMuiTheme({
+  palette: {
+    primary: pathfinderDarkGreen,
+    secondary: pathfinderLightGreen,
+  },
+});


### PR DESCRIPTION
In this PR:

- implemented Material-UI `ThemeProvider` and created a `theme` object with Pathfinder's colours
- fixed up styling for sign-in page

*Primary and secondary colours in use*
<img width="236" alt="Screen Shot 2020-05-08 at 15 56 37" src="https://user-images.githubusercontent.com/24999233/81455984-be516e00-9145-11ea-9ea3-87d4d2b02857.png">

*Badge with error colour applied*
<img width="220" alt="Screen Shot 2020-05-08 at 16 03 36" src="https://user-images.githubusercontent.com/24999233/81455986-c01b3180-9145-11ea-8771-067d80540beb.png">

*Sign-in page with styles fixed up*
<img width="964" alt="Screen Shot 2020-05-08 at 16 06 10" src="https://user-images.githubusercontent.com/24999233/81456020-db863c80-9145-11ea-97c5-448485b3a334.png">
