### PR TITLE
[Bug] [Intake form] Dependant field not clearing when depending on checklist value

### DIFF
--- a/src/intake-form/components/FormCheckBox.js
+++ b/src/intake-form/components/FormCheckBox.js
@@ -6,6 +6,9 @@ export const FormCheckBox = ({ form, field, value }) => {
   const { values, handleChange, handleBlur } = form;
   const { name, maxChecked = undefined } = field;
   const isChecked = values[name].includes(value);
+
+  const disabled = maxChecked && values[name].length >= maxChecked && !isChecked
+
   return (
     <FormControlLabel
       label={value}
@@ -16,11 +19,7 @@ export const FormCheckBox = ({ form, field, value }) => {
           checked={isChecked}
           value={value}
           name={name}
-          disabled={
-            maxChecked &&
-            values[name].length >= maxChecked &&
-            !isChecked
-          }
+          disabled={disabled}
         />
       }
     />

--- a/src/intake-form/components/FormFieldBuilder.js
+++ b/src/intake-form/components/FormFieldBuilder.js
@@ -5,6 +5,26 @@ import { FormRadioGroup } from './FormRadioGroup';
 import { FormCheckList } from './FormCheckList';
 import { FormSelect } from './FormSelect';
 
+const isFieldDisabled = (dependsOnOtherField, values, name) => {
+  let disabled = false;
+  if (!!dependsOnOtherField) {
+    // dependingField = field this field depends on
+    const { name: dependingFieldName, list, value: dependingFieldValue } = dependsOnOtherField;
+    if (list) {
+      // if dependingField is a list and doesn't include the correct value, disable this field
+      disabled = !values[dependingFieldName].includes(dependingFieldValue);
+    } else {
+      // if the depending field is not a list and is not set to the correct value, disable this field
+      disabled = values[dependingFieldName] !== dependingFieldValue;
+    }
+  }
+  // if this field is disabled, also clear its value
+  if (disabled) {
+    values[name] = '';
+  }
+  return disabled;
+};
+
 export const FormFieldBuilder = ({ form, field }) => {
   const { name, type, size } = field;
   let newField = null;
@@ -14,17 +34,15 @@ export const FormFieldBuilder = ({ form, field }) => {
       break;
     case 'radio':
       newField = (
-        <FormRadioGroup key={name} form={form} field={field} />
+        <FormRadioGroup key={name} form={form} field={field} isFieldDisabled={isFieldDisabled} />
       );
       break;
     case 'checklist':
-      newField = (
-        <FormCheckList key={name} form={form} field={field} />
-      );
+      newField = <FormCheckList key={name} form={form} field={field} />;
       break;
     default:
       newField = (
-        <FormTextField key={name} form={form} field={field} />
+        <FormTextField key={name} form={form} field={field} isFieldDisabled={isFieldDisabled} />
       );
   }
   return (

--- a/src/intake-form/components/FormRadioGroup.js
+++ b/src/intake-form/components/FormRadioGroup.js
@@ -6,37 +6,23 @@ import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 
-export const FormRadioGroup = ({ form, field }) => {
+export const FormRadioGroup = ({ form, field, isFieldDisabled }) => {
   const {
     values,
     errors,
     touched,
     handleChange,
-    handleBlur,
-    setFieldValue,
+    handleBlur
   } = form;
   const {
     name,
     options,
     label = undefined,
     required = undefined,
-    dependantFields = undefined,
     dependsOnOtherField = undefined,
   } = field;
 
-  const disabled =
-    !!dependsOnOtherField &&
-    values[dependsOnOtherField.name] !== dependsOnOtherField.value;
-
-  const handleDependantFieldChange = ({ target: { value } }) => {
-    if (!!dependantFields) {
-      dependantFields.forEach((field) => {
-        if (value !== field.value) {
-          setFieldValue(field.name, '');
-        }
-      });
-    }
-  };
+  const disabled = isFieldDisabled(dependsOnOtherField, values, name);
 
   return (
     <FormControl
@@ -49,10 +35,7 @@ export const FormRadioGroup = ({ form, field }) => {
         aria-label={name}
         name={name}
         value={values[name]}
-        onChange={(event) => {
-          handleChange(event);
-          handleDependantFieldChange(event);
-        }}
+        onChange={handleChange}
         onBlur={handleBlur}
         row
       >

--- a/src/intake-form/components/FormTextField.js
+++ b/src/intake-form/components/FormTextField.js
@@ -7,8 +7,8 @@ import { FastField } from 'formik';
 import { NumberMask } from './NumberMask';
 import './style/FormSteps.css';
 
-export const FormTextField = ({ form, field }) => {
-  const { values, errors, touched, handleChange, handleBlur, setFieldValue } = form;
+export const FormTextField = ({ form, field, isFieldDisabled }) => {
+  const { values, errors, touched, handleChange, handleBlur} = form;
   const {
     name,
     type,
@@ -16,7 +16,6 @@ export const FormTextField = ({ form, field }) => {
     description = undefined,
     multiline = undefined,
     required = undefined,
-    dependantFields = undefined,
     dependsOnOtherField = undefined,
     mask = undefined,
     adornment = undefined,
@@ -52,20 +51,7 @@ export const FormTextField = ({ form, field }) => {
     InputLabelProps: inputLabelProps,
   };
 
-  const isFieldDisabled = (dependsOnOtherField, values) => {
-    const { name, list, value } = dependsOnOtherField;
-    return list ? !values[name].includes(value) : values[name] !== value;
-  };
-
-  const handleDependantFieldChange = ({ target: { value } }) => {
-    if (!!dependantFields) {
-      dependantFields.forEach((field) => {
-        if (value !== field.value) {
-          setFieldValue(field.name, '');
-        }
-      });
-    }
-  };
+  const disabled = isFieldDisabled(dependsOnOtherField, values, name);
 
   return !!dependsOnOtherField ? (
     <FormControl component="fieldset" fullWidth>
@@ -80,19 +66,11 @@ export const FormTextField = ({ form, field }) => {
         onChange={handleChange}
         onBlur={handleBlur}
         value={values[name]}
-        disabled={isFieldDisabled(dependsOnOtherField, values)}
+        disabled={disabled}
       />
     </FormControl>
   ) : (
-    <FastField
-      name={name}
-      onChange={(event) => {
-        handleChange(event);
-        handleDependantFieldChange(event);
-      }}
-      onBlur={handleBlur}
-      value={values[name]}
-    >
+    <FastField name={name} onChange={handleChange} onBlur={handleBlur} value={values[name]}>
       {({ field }) => (
         <FormControl component="fieldset" fullWidth>
           {!!description && (

--- a/src/intake-form/components/IntakeForm.js
+++ b/src/intake-form/components/IntakeForm.js
@@ -16,7 +16,7 @@ import './style/IntakeForm.css';
 
 export const IntakeForm = (props) => {
   const { form } = props;
-  const { handleSubmit, isSubmitting } = form;
+  const { values, handleSubmit, isSubmitting } = form;
   const [currentStep, setCurrentStep] = useState(-1);
   const recaptchaRef = React.createRef();
   const { enqueueSnackbar } = useSnackbar();
@@ -231,7 +231,7 @@ export const IntakeForm = (props) => {
               color="primary"
               variant="contained"
               onClick={() => {
-                handleSubmit(form.values, form);
+                handleSubmit(values, form);
                 // TODO: only proceed to next step if pushing to database was successful,
                 // otherwise, show an error message somehow
                 handleClickNext(form);

--- a/src/intake-form/components/fields.js
+++ b/src/intake-form/components/fields.js
@@ -61,7 +61,7 @@ export const formSteps = [
       },
       {
         name: 'addressTimeLivedAt',
-        label: 'Time lived at this address',
+        label: 'Time lived here',
         size: 4,
         type: 'text',
       },
@@ -219,7 +219,6 @@ export const formSteps = [
         label: 'How did you find out about our program?',
         size: 12,
         type: 'radio',
-        dependantFields: [{ name: 'learnedAboutPathfinderOther', value: 'Other' }],
         options: [
           'Family and/or friends',
           'Teacher/counselor',
@@ -254,10 +253,6 @@ export const formSteps = [
         label: 'Have you ever attended a job club or paid employment training program?',
         type: 'radio',
         size: 8,
-        dependantFields: [
-          { name: 'employmentProgramInfo', value: 'Yes' },
-          { name: 'employmentProgramComplete', value: 'Yes' },
-        ],
         options: ['Yes', 'No'],
       },
       {
@@ -451,7 +446,6 @@ export const formSteps = [
         label: 'Do you have a bank account?',
         type: 'radio',
         size: 4,
-        dependantFields: [{ name: 'bankAccountType', value: 'Yes' }],
         options: ['Yes', 'No'],
       },
       {
@@ -471,7 +465,6 @@ export const formSteps = [
         label: 'What is your current form of income?',
         type: 'radio',
         size: 12,
-        dependantFields: [{ name: 'formOfIncomeOther', value: 'Other' }],
         options: [
           'None',
           'Employment insurance',
@@ -520,7 +513,6 @@ export const formSteps = [
         label: 'What is the main reason you are unemployed? (check all that apply to you)',
         type: 'checklist',
         size: 12,
-        dependantFields: [{ name: 'reasonsForUnemploymentOther', value: 'Other' }],
         options: [
           'I have just completed school or another training program',
           'I do not know how to do a good job search on my own',
@@ -596,7 +588,6 @@ export const formSteps = [
         label:
           'Do you have any health or physical concerns that may affect your ability to participate in our program?',
         type: 'radio',
-        dependantFields: [{ name: 'healthConcerns', value: 'Yes' }],
         options: ['Yes', 'No'],
       },
       {
@@ -624,7 +615,6 @@ export const formSteps = [
         label: "Do you have a valid driver's licence?",
         type: 'radio',
         size: 4,
-        dependantFields: [{ name: 'driversLicenseType', value: 'Yes' }],
         options: ['Yes', 'No'],
       },
       {
@@ -658,7 +648,6 @@ export const formSteps = [
         name: 'hasVolunteered',
         label: 'Have you ever volunteered?',
         type: 'radio',
-        dependantFields: [{ name: 'volunteerInfo', value: 'Yes' }],
         size: 4,
         options: ['Yes', 'No'],
       },
@@ -693,7 +682,6 @@ export const formSteps = [
         type: 'checklist',
         size: 12,
         maxChecked: 2,
-        dependantFields: [{ name: 'presentSituationAspectsOther', value: 'Other' }],
         options: [
           'Increase my self confidence',
           'Have more money and/or get out of poverty',
@@ -723,7 +711,6 @@ export const formSteps = [
         type: 'checklist',
         maxChecked: 2,
         size: 12,
-        dependantFields: [{ name: 'urgentNeedsOther', value: 'Other' }],
         options: [
           'Basic needs (food, shelter and clothing)',
           'The need to be independent',
@@ -772,7 +759,6 @@ export const formSteps = [
         label: 'Do you have any brothers or sisters?',
         type: 'radio',
         size: 4,
-        dependantFields: [{ name: 'siblings', value: 'Yes' }],
         options: ['Yes', 'No'],
       },
       {
@@ -791,7 +777,6 @@ export const formSteps = [
         name: 'hasChildren',
         label: 'Do you have any children?',
         size: 4,
-        dependantFields: [{ name: 'children', value: 'Yes' }],
         type: 'radio',
         options: ['Yes', 'No'],
       },


### PR DESCRIPTION
Fields that were dependant on checklist fields containing a specific field were not clearing when those requirements weren't met anymore (ie, a field requires another field to be checked "Other". If "Other" is unchecked later, the dependant field should become disabled and its value cleared)

In this PR:
- Fixed clearing of checklist dependant fields
- In fixing this bug, I discovered I could clear the field value when the `disabled` check is made, rather than when the dependant field is changed. Because of this, I was able to remove `dependantFields` from `formSteps`
- Wrote a general `isFieldDisabled` method and passed it down to fields that use it
- If we want to disable checklist fields depending on another field's value, we may want to revisit how `isFieldDisabled` works since it sets the value to an empty string and checklists are arrays