### PR TITLE
[FE] [Database App UI] Detailed participant page

### DIFF
--- a/src/constants/collectionType.js
+++ b/src/constants/collectionType.js
@@ -1,0 +1,4 @@
+export const collectionType = {
+  NEW: 'new',
+  PERMANENT: 'permanent',
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,2 +1,4 @@
 export * from './eventType';
 export * from './status';
+export * from './collectionType';
+export * from './masks';

--- a/src/constants/masks.js
+++ b/src/constants/masks.js
@@ -1,0 +1,5 @@
+export const masks = {
+  sin: '### ### ###',
+  bcCareCardNumber: '#### ### ###',
+  phone: '(###) ###-####',
+};

--- a/src/database/components/ListViewDrawer.js
+++ b/src/database/components/ListViewDrawer.js
@@ -19,6 +19,7 @@ import ListItemIcon from '@material-ui/core/ListItemIcon';
 import { makeStyles } from '@material-ui/core/styles';
 import { inject, observer } from 'mobx-react';
 import { participantStore, uiStore } from '../../injectables';
+import { collectionType } from '../../constants';
 import './style/NavDrawer.css';
 import { StyledListItem } from './StyledListItem';
 
@@ -39,7 +40,7 @@ export const ListViewDrawer = inject(
     const classes = useStyles();
     const [participantsListExpanded, setParticipantsListExpanded] = useState(false);
     const { currentViewMode, setCurrentViewMode, viewModes } = uiStore;
-    const { collectionType, collection } = participantStore;
+    const { collection } = participantStore;
 
     const statuses = [
       { name: 'Pending', icon: <HourglassEmptyOutlined /> },

--- a/src/database/components/ParticipantDetailEditView.js
+++ b/src/database/components/ParticipantDetailEditView.js
@@ -11,6 +11,7 @@ import { FormFieldBuilder, participantDetailSteps } from '../../fields';
 import service from '../../facade/service';
 import { AuthContext } from '../../sign-in';
 import { participantStore } from '../../injectables';
+import { collectionType } from '../../constants';
 
 export const ParticipantDetailEditView = ({
   participant,
@@ -20,7 +21,7 @@ export const ParticipantDetailEditView = ({
   onSuccessfulEdit,
 }) => {
   const { enqueueSnackbar } = useSnackbar();
-  const { collectionType } = participantStore;
+  
   const step = participantDetailSteps[currentStep];
   const {
     currentUser: { email: userID },

--- a/src/database/components/ParticipantDetailNotes.js
+++ b/src/database/components/ParticipantDetailNotes.js
@@ -11,6 +11,7 @@ import moment from 'moment';
 import { inject, observer } from 'mobx-react';
 import { participantStore } from '../../injectables';
 import { AuthContext } from '../../sign-in';
+import { collectionType } from '../../constants';
 import './style/ParticipantDetailNotes.css';
 import './style/ParticipantDetailPage.css';
 
@@ -18,7 +19,6 @@ export const ParticipantDetailNotes = inject('participantStore')(
   observer(() => {
     const {
       currentParticipant,
-      collectionType,
       setCurrentParticipant,
       collection,
     } = participantStore;

--- a/src/database/components/ParticipantDetailPage.js
+++ b/src/database/components/ParticipantDetailPage.js
@@ -8,6 +8,7 @@ import { participantDetailSteps } from '../../fields';
 import { ParticipantDetailEditView } from './ParticipantDetailEditView';
 import { ParticipantDetailNotes } from './ParticipantDetailNotes';
 import { ParticipantDetailHistory } from './ParticipantDetailHistory';
+import { ParticipantDetailView } from './ParticipantDetailView';
 import { inject, observer } from 'mobx-react';
 import { participantStore, uiStore } from '../../injectables';
 import './style/ParticipantDetailPage.css';
@@ -26,24 +27,6 @@ export const ParticipantDetailPage = inject(
     } = uiStore;
     const notesStep = participantDetailSteps.length - 2;
     const historyStep = participantDetailSteps.length - 1;
-
-    /**
-     * Placeholder component for detail view mode
-     */
-    const ParticipantDetailView = ({ currentParticipant, currentStep, handleClickChangeMode }) => (
-      <>
-        <div className="participant-detail-header">
-          <Typography variant="h5">Participant Details</Typography>
-          <Tooltip title="Edit participant record" aria-label="edit">
-            <IconButton onClick={handleClickChangeMode}>
-              <EditIcon />
-            </IconButton>
-          </Tooltip>
-        </div>
-        <Typography>Participant details go here</Typography>
-        <Typography>{`Viewing step #${currentStep}`}</Typography>
-      </>
-    );
 
     const getParticipantDetailContents = () => {
       if (currentParticipantDetailStep === notesStep) {
@@ -66,11 +49,18 @@ export const ParticipantDetailPage = inject(
         } else {
           return (
             <ParticipantDetailView
-              currentStep={currentParticipantDetailStep}
-              handleClickChangeMode={() =>
-                setCurrentParticipantDetailViewMode(participantDetailViewModes.EDIT)
-              }
-            />
+                participant={currentParticipant}
+                collection={collection}
+                currentStep={currentParticipantDetailStep}
+                handleClickChangeMode={() =>
+                  setCurrentParticipantDetailViewMode(participantDetailViewModes.EDIT)
+                }
+                handleClickMove={() => console.log('Move clicked')} // placeholder
+                // swap between deleteNew & deletePermanent depending on current collection
+                handleClickDelete={() => console.log('Delete clicked')} // placeholder
+                handleClickApprove={() => console.log('Approve clicked')} // placeholder
+                handleClickDeny={() => console.log('Deny clicked')} // placeholder
+              /> 
           );
         }
       }

--- a/src/database/components/ParticipantDetailView.js
+++ b/src/database/components/ParticipantDetailView.js
@@ -1,0 +1,174 @@
+import React, { useState } from 'react';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import EditIcon from '@material-ui/icons/Edit';
+import SaveIcon from '@material-ui/icons/Save';
+import DeleteIcon from '@material-ui/icons/DeleteForever';
+import ThumbUpIcon from '@material-ui/icons/ThumbUp';
+import ThumbDownIcon from '@material-ui/icons/ThumbDown';
+import Grid from '@material-ui/core/Grid';
+import Tooltip from '@material-ui/core/Tooltip';
+import NumberFormat from 'react-number-format';
+import { participantDetailSteps } from '../../fields';
+import { collectionType, masks } from '../../constants';
+import './style/ParticipantDetailView.css';
+
+export const ParticipantDetailView = ({
+  participant,
+  collection,
+  currentStep,
+  handleClickChangeMode,
+  handleClickMove,
+  handleClickDelete,
+  handleClickApprove,
+  handleClickDeny,
+}) => {
+  const step = participantDetailSteps[currentStep];
+  const participantName = `${participant.nameGiven} ${participant.nameLast}`;
+
+  const MaskedSIN = ({ sin }) => {
+    const maskedSIN = `XXX XXX ${sin.slice(6)} (click to show)`;
+    const formattedSIN = <NumberFormat value={sin} format={masks.sin} displayType="text" />;
+    const [showSIN, setShowSIN] = useState(false);
+    return (
+      <div className="participant-detail-SIN">
+        <Typography color="textSecondary" onClick={() => setShowSIN(!showSIN)}>
+          {showSIN ? formattedSIN : maskedSIN}
+        </Typography>
+      </div>
+    );
+  };
+
+  const renderFieldData = (field, data) => {
+    const { name, adornment } = field;
+    let renderedData = null;
+    if (data.length === 0 || data === undefined) {
+      renderedData = <em>None given</em>;
+    } else if (field.name === 'sin') {
+      return <MaskedSIN sin={data} />;
+    } else {
+      if (field.mask) {
+        renderedData = (
+          <NumberFormat
+            name={name}
+            value={data}
+            format={name.toLowerCase().includes('phone') ? masks.phone : masks[name]}
+            displayType="text"
+            prefix={adornment}
+            thousandSeparator={!!adornment}
+            decimalScale={2}
+            fixedDecimalScale={!!adornment}
+            isNumericString
+          />
+        );
+      } else {
+        renderedData = Array.isArray(data) ? data.join(', ') : data;
+      }
+    }
+    return <Typography color="textSecondary">{renderedData}</Typography>;
+  };
+
+  const getButtons = () => {
+    return collection === collectionType.NEW ? (
+      <div>
+        <Tooltip title="Edit submission" aria-label="edit">
+          <IconButton onClick={handleClickChangeMode}>
+            <EditIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Accept and save" aria-label="accept">
+          <IconButton
+            onClick={() => {
+              if (window.confirm('Accept and save this submission to the database?')) {
+                handleClickMove();
+              }
+            }}
+          >
+            <SaveIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Discard submission" aria-label="delete">
+          <IconButton
+            onClick={() => {
+              if (window.confirm('Discard submission? This cannot be undone.')) {
+                handleClickDelete();
+              }
+            }}
+          >
+            <DeleteIcon 
+            color="error"/>
+          </IconButton>
+        </Tooltip>
+      </div>
+    ) : (
+      <div>
+      <Tooltip title="Edit participant record" aria-label="edit">
+        <IconButton onClick={handleClickChangeMode}>
+          <EditIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Approve participant" aria-label="accept">
+        <IconButton
+          onClick={() => {
+            if (window.confirm('Approve participant')) {
+              handleClickApprove();
+            }
+          }}
+        >
+          <ThumbUpIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Deny participant" aria-label="accept">
+        <IconButton
+          onClick={() => {
+            if (window.confirm('Approve participant')) {
+              handleClickDeny();
+            }
+          }}
+        >
+          <ThumbDownIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Delete participant record" aria-label="delete">
+        <IconButton
+          onClick={() => {
+            if (window.confirm('Delete participant record?')) {
+              handleClickDelete();
+            }
+          }}
+        >
+          <DeleteIcon 
+          color="error"/>
+        </IconButton>
+      </Tooltip>
+    </div>
+    );
+  };
+
+  return (
+    <>
+      <div className="participant-detail-header">
+        <div>
+          <Typography variant="h6">{`Participant Details - ${step.stepName}`}</Typography>
+          <Typography variant="h4">{participantName}</Typography>
+        </div>
+        {getButtons()}
+      </div>
+      <div className="participant-detail-form-contents">
+        <Grid container spacing={2}>
+          {step.fields.map((field) => {
+            const { name, size, detailSize, prettyName } = field;
+            // if both size & detailSize undefined, use true, else use detailSize if defined, size if not
+            const viewSize = !detailSize && !size ? true : !!detailSize ? detailSize : size;
+            return (
+              <Grid key={name} item md={viewSize} xs={12}>
+                <Typography variant="button">{prettyName}</Typography>{' '}
+                {renderFieldData(field, participant[name])}
+              </Grid>
+            );
+          })}
+        </Grid>
+      </div>
+    </>
+  );
+};

--- a/src/database/components/style/ParticipantDetailView.css
+++ b/src/database/components/style/ParticipantDetailView.css
@@ -1,0 +1,3 @@
+.participant-detail-SIN {
+  cursor: pointer;
+}

--- a/src/fields/NumberMask.js
+++ b/src/fields/NumberMask.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import NumberFormat from 'react-number-format';
-
-const masks = {
-  sin: '### ### ###',
-  bcCareCardNumber: '#### ### ###',
-  phone: '(###) ###-####',
-};
+import { masks }  from '../constants';
 
 export const NumberMask = (props) => {
   const { inputRef, onChange, name, ...other } = props;

--- a/src/fields/fields.js
+++ b/src/fields/fields.js
@@ -116,6 +116,7 @@ export const formSteps = [
         label: 'Emergency contact name',
         type: 'text',
         size: 12,
+        detailSize: 6
       },
       {
         name: 'emergencyContact1Relationship',
@@ -123,6 +124,7 @@ export const formSteps = [
         label: 'Relationship to you',
         type: 'text',
         size: 12,
+        detailSize: 6
       },
       {
         name: 'emergencyContact1PhoneHome',
@@ -155,6 +157,7 @@ export const formSteps = [
         label: 'Emergency contact name',
         type: 'text',
         size: 12,
+        detailSize: 6
       },
       {
         name: 'emergencyContact2Relationship',
@@ -162,6 +165,7 @@ export const formSteps = [
         label: 'Relationship to you',
         type: 'text',
         size: 12,
+        detailSize: 6
       },
       {
         name: 'emergencyContact2PhoneHome',
@@ -241,6 +245,7 @@ export const formSteps = [
         prettyName: 'Found out about Pathfinder',
         label: 'How did you find out about our program?',
         size: 12,
+        detailSize: 6,
         type: 'radio',
         options: [
           'Family and/or friends',
@@ -265,6 +270,7 @@ export const formSteps = [
           'If you answered "other" to "How did you find out about our program?", please specify:',
         label: 'If other, please specify',
         size: 12,
+        detailSize: 6,
         multiline: true,
         dependsOnOtherField: {
           name: 'learnedAboutPathfinder',
@@ -278,6 +284,7 @@ export const formSteps = [
         label: 'Have you ever attended a job club or paid employment training program?',
         type: 'radio',
         size: 8,
+        detailSize: 6,
         options: ['Yes', 'No'],
       },
       {
@@ -286,6 +293,7 @@ export const formSteps = [
         label: 'Did you complete the job club or paid employment program?',
         type: 'radio',
         size: 4,
+        detailSize: 6,
         options: ['Yes', 'No'],
         dependsOnOtherField: {
           name: 'hasEmploymentProgramTraining',
@@ -319,6 +327,7 @@ export const formSteps = [
         type: 'radio',
         required: true,
         size: 12,
+        detailSize: 6,
         options: ['Male', 'Female', 'Other', 'Decline to answer'],
       },
       {
@@ -346,6 +355,7 @@ export const formSteps = [
         type: 'radio',
         required: true,
         size: 12,
+        detailSize: 6,
         options: [
           'Registered on-reserve',
           'Registered off-reserve',
@@ -372,6 +382,7 @@ export const formSteps = [
         type: 'radio',
         required: true,
         size: 12,
+        detailSize: 6,
         options: [
           'Elementary',
           'Secondary incomplete',
@@ -419,6 +430,7 @@ export const formSteps = [
         label: 'Do you have any mental health issues? (e.g., anxiety, depression, mood disorder, schizophrenia, etc.)',
         required: true,
         size: 12,
+        detailSize: 4,
         options: ['Yes', 'No', 'Decline to answer'],
       },
       {
@@ -430,6 +442,7 @@ export const formSteps = [
         label: 'If yes, please specify',
         multiline: true,
         size: 12,
+        detailSize: 8,
         dependsOnOtherField: {
           name: 'hasMentalHealthIssues',
           list: false,
@@ -486,6 +499,7 @@ export const formSteps = [
         prettyName: "Housing situation",
         type: 'radio',
         size: 12,
+        detailSize: 4,
         required: true,
         label:
           'What is your current housing situation?',
@@ -506,6 +520,7 @@ export const formSteps = [
           'If you answered "other" to "What is your current housing situation?", please specify:',
         label: 'If other, please specify',
         size: 6,
+        detailSize: 8,
         multiline: true,
         dependsOnOtherField: {
           name: 'housingSituation',
@@ -518,10 +533,11 @@ export const formSteps = [
         prettyName: "Rent",
         type: 'number',
         size: 6,
+        detailSize: 12,
         description:
           'How much do you pay for rent per month? (Please put $0 if you are not required to pay rent at your place of residence or where you are staying)',
-
         adornment: '$',
+        mask: 'rent'
       },
       {
         name: 'hasBankAccount',
@@ -529,6 +545,7 @@ export const formSteps = [
         label: 'Do you have a bank account?',
         type: 'radio',
         size: 4,
+        detailSize: 4,
         options: ['Yes', 'No'],
       },
       {
@@ -537,6 +554,7 @@ export const formSteps = [
         label: 'If yes, is your bank account a chequing or savings account or do you have both?',
         type: 'radio',
         size: 8,
+        detailSize: 8,
         dependsOnOtherField: {
           name: 'hasBankAccount',
           list: false,
@@ -550,6 +568,7 @@ export const formSteps = [
         label: 'What is your current form of income?',
         type: 'radio',
         size: 12,
+        detailSize: 4,
         options: [
           'None',
           'Employment insurance',
@@ -569,6 +588,7 @@ export const formSteps = [
           'If you answered "other" to "What is your current form of income?", please specify:',
         label: 'If other, please specify',
         size: 12,
+        detailSize: 8,
         multiline: true,
         dependsOnOtherField: {
           name: 'formOfIncome',
@@ -872,6 +892,7 @@ export const formSteps = [
         label: 'Do you have any brothers or sisters?',
         type: 'radio',
         size: 4,
+        detailSize: 6,
         options: ['Yes', 'No'],
       },
       {
@@ -879,6 +900,7 @@ export const formSteps = [
         prettyName: "Siblings details",
         type: 'text',
         size: 8,
+        detailSize: 6,
         description: 'If you have brothers or sisters, who do you like the most and why?',
         multiline: true,
         dependsOnOtherField: {
@@ -892,6 +914,7 @@ export const formSteps = [
         prettyName: "Has children",
         label: 'Do you have any children?',
         size: 4,
+        detailSize: 6,
         type: 'radio',
         options: ['Yes', 'No'],
       },
@@ -900,6 +923,7 @@ export const formSteps = [
         prettyName: "Children details",
         type: 'text',
         size: 8,
+        detailSize: 6,
         description: 'If you have children, how many and what are their names?',
         multiline: true,
         dependsOnOtherField: {
@@ -914,6 +938,7 @@ export const formSteps = [
         label: 'Have you ever travelled outside British Columbia?',
         type: 'radio',
         size: 4,
+        detailSize: 6,
         options: ['Yes', 'No'],
       },
       {
@@ -922,6 +947,7 @@ export const formSteps = [
         label: 'Do you have a current resume and cover page?',
         type: 'radio',
         size: 4,
+        detailSize: 6,
         options: ['Yes', 'No'],
       },
       {

--- a/src/injectables/ParticipantStore.js
+++ b/src/injectables/ParticipantStore.js
@@ -1,4 +1,5 @@
 import { action, autorun, computed, decorate, observable } from 'mobx';
+import { collectionType } from '../constants';
 import service from '../facade/service';
 
 const db = service.getDatabase();
@@ -8,10 +9,6 @@ const checkEqual = (obj1, obj2) => {
 };
 
 class ParticipantStore {
-  collectionType = {
-    NEW: 'new',
-    PERMANENT: 'permanent',
-  };
 
   documentType = {
     ADDED: 'added',
@@ -29,7 +26,7 @@ class ParticipantStore {
 
   _currentParticipant = null;
 
-  _collection = this.collectionType.PERMANENT;
+  _collection = collectionType.PERMANENT;
 
   _controller = null;
 
@@ -89,7 +86,7 @@ class ParticipantStore {
       }
 
       switch (this._collection) {
-        case this.collectionType.NEW:
+        case collectionType.NEW:
           this._controller = db.getNewList(
             this._filter,
             this._sorter,
@@ -98,7 +95,7 @@ class ParticipantStore {
           );
           break;
 
-        case this.collectionType.PERMANENT:
+        case collectionType.PERMANENT:
           this._controller = db.getPermanentList(
             this._filter,
             this._sorter,


### PR DESCRIPTION
In this PR:
- Created participant detail component
- Added record control buttons (edit, save, delete, etc)
- Added SIN masking
- Moved `collectionType` and `masks` to `constants`

*Permanent record*
<img width="789" alt="Screen Shot 2020-05-14 at 20 36 05" src="https://user-images.githubusercontent.com/24999233/82009358-f6641f80-9623-11ea-8968-60251b8a8b10.png">

*New record*
<img width="788" alt="Screen Shot 2020-05-14 at 20 37 58" src="https://user-images.githubusercontent.com/24999233/82009363-f7954c80-9623-11ea-8be0-b1be0f451ac2.png">

*Demo*
![Screen-Recording-2020-05-14-at-2](https://user-images.githubusercontent.com/24999233/82009365-f82de300-9623-11ea-8351-d3267c7ef499.gif)
