### PR TITLE
[WIP][Routing] Handle navigating back to database when user already logged in

### DIFF
--- a/src/sign-in/components/Login.js
+++ b/src/sign-in/components/Login.js
@@ -23,6 +23,12 @@ export class LogIn extends Component {
     };
   }
 
+  componentDidMount() {
+    if (this.authService.getCurrentUser()) {
+      navigate('/database');
+    }
+  }
+
   /**
    * handles log in event
    * @param {event: onSubmit event}


### PR DESCRIPTION
When the currently signed-in user tries to go back to sign-in page by clicking browser go back button, sign-in page will check the current user status, navigate back to database page automatically if the user has not signed-out.
![a3fddffa24a6f8eb45403460888e88b4](https://user-images.githubusercontent.com/43553017/82080117-d91d6880-9698-11ea-91ac-b30c92e3785d.gif)

Problem to solve: when the currently signed-in user type ./sign-in URL on address bar, the address will change from ./sign-in to ./database, but the UI stays on Login page, and does not refresh/load database UI. Possbile cause: lifecycle method.
![db-route-bug](https://user-images.githubusercontent.com/43553017/82080100-d3278780-9698-11ea-8108-e079b3dd423a.PNG)
