### PR TITLE
[Database App Functions] Add "undo delete" button to snackbar for deleting permanent records

### DIFF
--- a/src/database/components/ParticipantDetailEdit.js
+++ b/src/database/components/ParticipantDetailEdit.js
@@ -21,16 +21,6 @@ export const ParticipantDetailEdit = ({
   } = useContext(AuthContext);
   const userID = !!displayName ? displayName : email;
 
-  const handleClickOk = () => {
-    return window.confirm('Confirm changes?');
-  };
-
-  const handleClickCancel = () => {
-    if (window.confirm('Discard changes? Record will not be saved.')) {
-      handleClickChangeMode();
-    }
-  };
-
   const handleSubmit = (values, setSubmitting) => {
     const db = service.getDatabase();
     collection === collectionType.NEW

--- a/src/database/components/ParticipantDetailPageHeader.js
+++ b/src/database/components/ParticipantDetailPageHeader.js
@@ -90,10 +90,10 @@ export const ParticipantDetailPageHeader = ({
               </IconButton>
             </Tooltip>
           )}
-          <Tooltip title="Delete participant record" aria-label="delete">
+          <Tooltip title="Archive participant record" aria-label="archive">
             <IconButton
               onClick={() => {
-                if (window.confirm('Delete participant record?')) {
+                if (window.confirm('Archive participant record?')) {
                   handleClickDelete();
                 }
               }}

--- a/src/database/components/ParticipantDetailView.js
+++ b/src/database/components/ParticipantDetailView.js
@@ -2,6 +2,7 @@ import React, { useState, useContext } from 'react';
 import { useSnackbar } from 'notistack';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
 import NumberFormat from 'react-number-format';
 import { participantDetailSteps } from '../../fields';
 import { ParticipantDetailPageHeader } from './ParticipantDetailPageHeader';
@@ -9,7 +10,6 @@ import { ParticipantApproveDialog } from './ParticipantApproveDialog';
 import { participantDetailViewModes, collectionType, masks } from '../../constants';
 import service from '../../facade/service';
 import { AuthContext } from '../../sign-in';
-
 import './style/ParticipantDetailView.css';
 
 export const ParticipantDetailView = ({
@@ -43,7 +43,7 @@ export const ParticipantDetailView = ({
   const renderFieldData = (field, data) => {
     const { name, adornment } = field;
     let renderedData = null;
-    if (data.length === 0 || data === undefined) {
+    if (data === undefined || data.length === 0) {
       renderedData = <em>None</em>;
     } else if (field.name === 'sin') {
       return <MaskedSIN sin={data} />;
@@ -109,17 +109,40 @@ export const ParticipantDetailView = ({
       : db.deletePermanent(
           participant,
           userID,
-          (success) => {
-            enqueueSnackbar('Participant record removed. Undo?');
+          (updatedParticpant) => {
+            enqueueSnackbar('Participant record archived.', {
+              action: (
+                <Button color="secondary" onClick={() => handleClickUndoDelete(updatedParticpant, userID)}>
+                  Undo
+                </Button>
+              ),
+              autoHideDuration: 3000,
+            });
             handleClickChangeView();
           },
           (error) => {
-            enqueueSnackbar('There was a problem removing the participant record.', {
+            enqueueSnackbar('There was a problem archiving the participant record.', {
               variant: 'error',
             });
             handleClickChangeView();
           },
         );
+  };
+
+  const handleClickUndoDelete = (participant, userID) => {
+    const db = service.getDatabase();
+    db.undoDeletePermanent(
+      participant,
+      userID,
+      (success) => {
+        enqueueSnackbar('Participant record restored.', { variant: 'success' });
+      },
+      (error) => {
+        enqueueSnackbar('There was a problem restoring the participant record.', {
+          variant: 'error',
+        });
+      },
+    );
   };
 
   const handleClickApprove = (confirmationNumber) => {

--- a/src/facade/DatabaseManager.js
+++ b/src/facade/DatabaseManager.js
@@ -222,7 +222,7 @@ export default class DatabaseManager {
     let document = { ...participant };
     delete document.id;
     this._updateCaseInsensitiveFields(document);
-    
+
     ref
       .doc(docId)
       .update(document)
@@ -347,16 +347,21 @@ export default class DatabaseManager {
     const updatedHistory = this.getUpdatedHistory(
       userName,
       eventType.DELETED,
-      'Participant record deleted',
+      'Participant record archived',
       oldHistory,
     );
+
     let document = {
       status: STATUS.deleted,
       prevStatus: status,
       history: updatedHistory,
     };
 
-    this.permanentRef.doc(docId).update(document).then(onSuccess).catch(onError);
+    this.permanentRef
+      .doc(docId)
+      .update(document)
+      .then(onSuccess({ ...data, ...document }))
+      .catch(onError);
   }
 
   /**


### PR DESCRIPTION
In this PR:
- connected `undoDeletePermanent` database function to a button on the snackbar that appears after a delete is performed
- reworded "delete" to "archive" for deleting permanent records
- cleaned up a bit of code

*Demo*
![Screen-Recording-2020-05-15-at-2](https://user-images.githubusercontent.com/24999233/82111737-0bac7d00-96fc-11ea-9de0-40415b88bd4d.gif)