### PR TITLE
[Participant Detail Page] Notes page shouldn't allow empty notes & Shouldn't send an updated record to the db if no fields have actually been changed

### DIFF
--- a/src/database/components/participantDetail/ParticipantDetailEdit.js
+++ b/src/database/components/participantDetail/ParticipantDetailEdit.js
@@ -2,20 +2,20 @@ import React, { useContext } from 'react';
 import { useSnackbar } from 'notistack';
 import { participantDetailSteps } from '../../../fields';
 import { AuthContext } from '../../../sign-in';
-import { collectionType, participantDetailViewModes } from '../../../constants';
+import { participantDetailViewModes, status } from '../../../constants';
 import service from '../../../facade/service';
 import { ParticipantDetailForm } from './ParticipantDetailForm';
 import '../style/ParticipantDetailPage.css';
 
 export const ParticipantDetailEdit = ({
   participant,
-  collection,
   currentStep,
   handleClickChangeMode,
   onSuccessfulEdit,
 }) => {
   const { enqueueSnackbar } = useSnackbar();
   const step = participantDetailSteps[currentStep];
+  const { status: participantStatus } = participant;
   const {
     currentUser: { email, displayName },
   } = useContext(AuthContext);
@@ -23,49 +23,55 @@ export const ParticipantDetailEdit = ({
 
   const handleSubmit = (values, setSubmitting) => {
     const db = service.getDatabase();
-    collection === collectionType.NEW
-      ? db.updateNew(
-          participant, // old data
-          values, // new data from form
-          userID, // user
-          (updatedParticipant) => {
-            setSubmitting(false);
-            enqueueSnackbar('Participant record updated.', {
-              variant: 'success',
-            });
-            onSuccessfulEdit(updatedParticipant);
-            handleClickChangeMode();
-          },
-          (error) => {
-            enqueueSnackbar('There was a problem updating the participant record.', {
-              variant: 'error',
-            });
-            handleClickChangeMode();
-          },
-        )
-      : db.updatePermanent(
-          participant,
-          values,
-          userID,
-          (updatedParticipant) => {
-            setSubmitting(false);
-            enqueueSnackbar('Participant record updated.', {
-              variant: 'success',
-            });
-            onSuccessfulEdit(updatedParticipant);
-            handleClickChangeMode();
-          },
-          (error) => {
-            let message = error.name === 'DuplicateError'
-              ? 'Unable to save participant record, record with that SIN already exists'
-              : 'There was a problem saving the participant record.';
+    if (participant !== values) { // if there were changes
+      participantStatus === status.NEW
+        ? db.updateNew(
+            participant, // old data
+            values, // new data from form
+            userID, // user
+            (updatedParticipant) => {
+              setSubmitting(false);
+              enqueueSnackbar('Participant record updated.', {
+                variant: 'success',
+              });
+              onSuccessfulEdit(updatedParticipant);
+              handleClickChangeMode();
+            },
+            (error) => {
+              enqueueSnackbar('There was a problem updating the participant record.', {
+                variant: 'error',
+              });
+              handleClickChangeMode();
+            },
+          )
+        : db.updatePermanent(
+            participant,
+            values,
+            userID,
+            (updatedParticipant) => {
+              setSubmitting(false);
+              enqueueSnackbar('Participant record updated.', {
+                variant: 'success',
+              });
+              onSuccessfulEdit(updatedParticipant);
+              handleClickChangeMode();
+            },
+            (error) => {
+              let message =
+                error.name === 'DuplicateError'
+                  ? 'Unable to save participant record, record with that SIN already exists'
+                  : 'There was a problem saving the participant record.';
 
-            enqueueSnackbar(message, {
-              variant: 'error',
-            });
-            handleClickChangeMode();
-          },
-        );
+              enqueueSnackbar(message, {
+                variant: 'error',
+              });
+              handleClickChangeMode();
+            },
+          );
+    } else {
+      enqueueSnackbar('No changes made.');
+      handleClickChangeMode();
+    }
   };
 
   return (

--- a/src/database/components/participantDetail/ParticipantDetailNotes.js
+++ b/src/database/components/participantDetail/ParticipantDetailNotes.js
@@ -24,10 +24,14 @@ export const ParticipantDetailNotes = inject('participantStore')(
     } = useContext(AuthContext);
     const [newNoteFieldValue, setNewNoteFieldValue] = useState('');
     const [isSubmitting, setSubmitting] = useState(false);
+    const [error, setError] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
     const notes = !!currentParticipant.notes ? currentParticipant.notes : [];
 
     const handleChange = ({ target: { value } }) => {
+      if (value !== '') {
+        setError(false);
+      }
       setNewNoteFieldValue(value);
     };
 
@@ -65,6 +69,7 @@ export const ParticipantDetailNotes = inject('participantStore')(
               setSubmitting(false);
             },
             (error) => {
+              console.log(error)
               enqueueSnackbar('There was a problem adding the note.', {
                 variant: 'error',
               });
@@ -73,21 +78,26 @@ export const ParticipantDetailNotes = inject('participantStore')(
     };
 
     const addNote = () => {
-      const now = moment.utc().format();
-      const note = {
-        text: newNoteFieldValue,
-        timeStamp: now,
-        user: userID,
-      };
-
-      const newNotes = [note, ...notes];
-      if (window.confirm('Add new note?')) {
-        const newValues = {
-          ...currentParticipant,
-          notes: newNotes,
+      if (newNoteFieldValue === '') {
+        setError(true);
+      } else {
+        
+        const now = moment.utc().format();
+        const note = {
+          text: newNoteFieldValue,
+          timeStamp: now,
+          user: userID,
         };
-        setSubmitting(true);
-        handleNoteSubmit(newValues);
+
+        const newNotes = [note, ...notes];
+        if (window.confirm('Add new note?')) {
+          const newValues = {
+            ...currentParticipant,
+            notes: newNotes,
+          };
+          setSubmitting(true);
+          handleNoteSubmit(newValues);
+        }
       }
     };
 
@@ -107,6 +117,8 @@ export const ParticipantDetailNotes = inject('participantStore')(
               label={label}
               value={newNoteFieldValue}
               onChange={handleChange}
+              error={error}
+              helperText={error && 'Note cannot be blank'}
               fullWidth
               multiline
             />

--- a/src/database/components/participantDetail/ParticipantDetailPage.js
+++ b/src/database/components/participantDetail/ParticipantDetailPage.js
@@ -36,7 +36,6 @@ export const ParticipantDetailPage = inject(
           return (
             <ParticipantDetailEdit
               participant={currentParticipant}
-              collection={collection}
               currentStep={currentParticipantDetailStep}
               handleClickChangeMode={() =>
                 setCurrentParticipantDetailViewMode(participantDetailViewModes.VIEW)


### PR DESCRIPTION
In this PR:
- Added error handling for empty notes
- Added bypassing pushing an update to the db if a user tries updating a record but makes no changes (including user feedback snackbar)

*Empty note error handling*
![Screen-Recording-2020-05-18-at-1](https://user-images.githubusercontent.com/24999233/82242735-37458800-98f3-11ea-9b92-208dbd8e4f3a.gif)

*No changes made, then showing history has not been updated*
![Screen-Recording-2020-05-18-at-1 (1)](https://user-images.githubusercontent.com/24999233/82242728-33b20100-98f3-11ea-98a9-950eb40da1c9.gif)
