### PR TITLE
[Participant Detail] Remove notes and history tabs when the user is in edit mode

### DIFF
--- a/src/database/components/navDrawer/ParticipantTabs.js
+++ b/src/database/components/navDrawer/ParticipantTabs.js
@@ -10,7 +10,7 @@ export const ParticipantTabs = inject('uiStore')(
   observer(({ handleClick }) => {
     const { currentParticipantDetailStep, currentParticipantDetailViewMode } = uiStore;
     const steps =
-      currentParticipantDetailViewMode === participantDetailViewModes.CREATE
+      currentParticipantDetailViewMode !== participantDetailViewModes.VIEW
         ? stepNames
         : participantDetailStepNames;
 


### PR DESCRIPTION
In this PR:
- Remove the note and history tabs from the nave drawer when the user is in edit mode