### PR TITLE
[FE] Set participantStore to clear when user logs out

### DIFF
--- a/src/database/components/TopNavBar.js
+++ b/src/database/components/TopNavBar.js
@@ -9,6 +9,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import Tooltip from '@material-ui/core/Tooltip';
 import service from '../../facade/service';
+import { participantStore } from '../../injectables'
 import './style/TopNavBar.css';
 
 const authService = service.getAuthentication();
@@ -45,8 +46,13 @@ export const TopNavBar = ({ drawerState, handleDrawerOpen }) => {
   const classes = useStyles();
   const title = 'Pathfinder Youth Centre Society Participant Database';
 
+  /**
+   * Signs the user out and clears the data from the participant store
+   */
   const handleSignOut = () => {
-    authService.signOut();
+    authService.signOut(() => {
+      participantStore.clearStore()
+    });
   };
 
   return (

--- a/src/injectables/ParticipantStore.js
+++ b/src/injectables/ParticipantStore.js
@@ -186,6 +186,19 @@ class ParticipantStore {
   get limit() {
     return this._limit;
   }
+
+  clearStore = () => {
+    this._filter = { status: null };
+    this._sorter = { createdAt: 'desc' };
+    this._limit = 20;
+    this._participants = [];
+    this._currentParticipant = null;
+    this._collection = collectionType.PERMANENT;
+    this._controller = null;
+    this._isLastPage = true;
+    this._statistics = null;
+    this.isListLoading = false;
+  }
 }
 
 decorate(ParticipantStore, {
@@ -210,6 +223,7 @@ decorate(ParticipantStore, {
   numOfNewParticipants: computed,
   isLastPage: computed,
   limit: computed,
+  clearStore: action
 });
 
 let participantStore = new ParticipantStore();

--- a/src/injectables/UIStore.js
+++ b/src/injectables/UIStore.js
@@ -63,8 +63,6 @@ class UIStore {
 
   navigationDrawerOpen = false;
 
-  isListLoading = true;
-
   get headers() {
     return this.currentViewMode === viewModes.STAFF_LIST
       ? this.staffHeaders


### PR DESCRIPTION
In this PR:
- added a `clearStore` method to `participantStore` that empties it of all its data and resets observables back to initial values
- when `signOut` is called, `clearStore` is called on success

Decided against clearing the `uiStore` and `userStore` since they don't hold any sensitive data and are used in places where the user doesn' need to be authenticated (such as the user list to check if a user email has been authenticated)