### PR TITLE
[User Management] delete unauthorized firebase user account

### DIFF
--- a/src/sign-in/components/Login.js
+++ b/src/sign-in/components/Login.js
@@ -91,8 +91,22 @@ export const LogIn = () => {
       email.toLocaleLowerCase(),
       // if email doesn't exist in user collection
       () => {
-        setSubmitting(false);
-        setErrorMessage('User account not authorized. Please contact Pathfinder administration.');
+        // delete account if account exists in firebase auth user list
+        authService.logIn(
+          email,
+          password,
+          () => {
+            authService.getCurrentUser().delete();
+            setSubmitting(false);
+            setErrorMessage('User account does not exist.');
+          },
+          () => {
+            setSubmitting(false);
+            setErrorMessage(
+              'User account not authorized. Please contact Pathfinder administration.',
+            );
+          },
+        );
       },
       // if email exists in user collection
       () => {


### PR DESCRIPTION
Added a few lines in login.js. Any firebase active user account will be deleted at first login attempt after the user is removed from user collection by admin.
Test case:
delete Charlie from user collection:
![image](https://user-images.githubusercontent.com/43553017/82487647-89251400-9a93-11ea-9fed-8fc3ab014647.png)


Charlie tries to login after his account was removed from user collection. The account will be deleted from firebase auth user list.
![3c77298c76b72609718bea02c09c2ef9](https://user-images.githubusercontent.com/43553017/82490837-ac9e8d80-9a98-11ea-818b-e4f4c0e9ee0f.gif)

