### PR TITLE
[FE] Added space to logo on login page

### DIFF
--- a/src/sign-in/components/Login.css
+++ b/src/sign-in/components/Login.css
@@ -22,6 +22,7 @@
 
 .login-logo {
   width: 15em;
+  padding-top: 2em;
 }
 
 .login-bottom-links {

--- a/src/sign-in/components/Login.js
+++ b/src/sign-in/components/Login.js
@@ -137,7 +137,7 @@ export const LogIn = () => {
       <div className="login-content">
         <img className="login-logo" src={Logo} alt="Pathfinder Youth Centre Society logo" />
         <Typography align="center" variant="h5">
-          PYCS Staff Login Portal
+          Staff Login Portal
         </Typography>
         <Formik
           initialValues={initialValues}


### PR DESCRIPTION
PYCS logo was touching the top bar, I gave it a bit of room.