### PR TITLE
[Database UI] Undo delete snackbar is way too fast

### DIFF
--- a/src/database/components/participantDetail/ParticipantDetailView.js
+++ b/src/database/components/participantDetail/ParticipantDetailView.js
@@ -159,7 +159,7 @@ export const ParticipantDetailView = ({
                 Undo
               </Button>
             ),
-            autoHideDuration: 3000,
+            autoHideDuration: 60000,
           });
           handleClickChangeView();
         },


### PR DESCRIPTION
In this PR:
- Extended time undo delete snackbar stays on the screen

Note: `autoHideDuration` is supposed to be a value in milliseconds, but the snackbar falls off the screen at 30 seconds even when set to `60000`. When testing, however, this duration seemed like plenty, so I've left it.