### PR TITLE
[Participant Detail] Remove 'notes' and 'action plan' tabs from the sidebar for new applications

### DIFF
--- a/src/database/components/navDrawer/DetailViewDrawer.js
+++ b/src/database/components/navDrawer/DetailViewDrawer.js
@@ -5,44 +5,49 @@ import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import Divider from '@material-ui/core/Divider';
 import { ArrowBack } from '@material-ui/icons';
-import { uiStore } from '../../../injectables';
+import { participantStore, uiStore } from '../../../injectables';
 import { participantDetailViewModes, viewModes } from '../../../constants';
 import { StyledListItem } from '../StyledListItem';
 import { ParticipantTabs } from './ParticipantTabs';
 import '../style/NavDrawer.css';
 
-export const DetailViewDrawer = inject('uiStore')(
-  observer(({handleDrawerClose}) => {
+export const DetailViewDrawer = inject(
+  'participantStore',
+  'uiStore',
+)(
+  observer(({ handleDrawerClose }) => {
+    const { collection } = participantStore;
     const {
       setCurrentViewMode,
       currentListViewMode,
       currentDetailViewMode,
+      currentParticipantDetailStep,
       currentParticipantDetailViewMode,
       setCurrentParticipantDetailStep,
       setCurrentParticipantDetailViewMode,
     } = uiStore;
 
     const handleResetPage = () => {
-        setCurrentViewMode(currentListViewMode);
-        setCurrentParticipantDetailViewMode(participantDetailViewModes.VIEW);
-        setCurrentParticipantDetailStep(0);
-        handleDrawerClose()
-    }
+      setCurrentViewMode(currentListViewMode);
+      setCurrentParticipantDetailViewMode(participantDetailViewModes.VIEW);
+      setCurrentParticipantDetailStep(0);
+      handleDrawerClose();
+    };
 
     const handleClickBack = () => {
       if (
         currentParticipantDetailViewMode !== participantDetailViewModes.VIEW &&
         window.confirm('Leave this page? Any unsaved changes will be lost.')
       ) {
-        handleResetPage()
+        handleResetPage();
       } else {
-        handleResetPage()
+        handleResetPage();
       }
     };
 
     const handleChangeParticipantTab = (tabIndex) => {
       setCurrentParticipantDetailStep(tabIndex);
-      handleDrawerClose()
+      handleDrawerClose();
     };
 
     return (
@@ -51,11 +56,16 @@ export const DetailViewDrawer = inject('uiStore')(
           <ListItemIcon>
             <ArrowBack />
           </ListItemIcon>
-          <ListItemText primary={'Back'} />
+          <ListItemText primary="Back" />
         </StyledListItem>
         <Divider />
         {currentDetailViewMode === viewModes.PARTICIPANT_DETAIL && (
-          <ParticipantTabs handleClick={handleChangeParticipantTab} />
+          <ParticipantTabs
+            handleClick={handleChangeParticipantTab}
+            viewMode={currentParticipantDetailViewMode}
+            stepIndex={currentParticipantDetailStep}
+            collection={collection}
+          />
         )}
       </List>
     );

--- a/src/database/components/navDrawer/ParticipantTabs.js
+++ b/src/database/components/navDrawer/ParticipantTabs.js
@@ -1,40 +1,40 @@
 import React from 'react';
-import { inject, observer } from 'mobx-react';
 import ListItemText from '@material-ui/core/ListItemText';
-import { uiStore } from '../../../injectables';
-import { participantDetailViewModes } from '../../../constants';
-import { participantDetailStepNames, stepNames } from '../../../fields';
+import { collectionType, participantDetailViewModes } from '../../../constants';
+import { participantDetailStepNames, stepNames, getStepIndexFromStepName } from '../../../fields';
 import { StyledListItem } from '../StyledListItem';
 
-export const ParticipantTabs = inject('uiStore')(
-  observer(({ handleClick }) => {
-    const { currentParticipantDetailStep, currentParticipantDetailViewMode } = uiStore;
-    const steps =
-      currentParticipantDetailViewMode !== participantDetailViewModes.VIEW
-        ? stepNames
-        : participantDetailStepNames;
-
-    const handleCategoryClick = (clickedCategory) => {
-      handleClick(clickedCategory);
-    };
-
-    return (
-      <>
-        {steps.map((tab, index) => {
-          return (
-            !!tab && (
-              <StyledListItem
-                button
-                selected={currentParticipantDetailStep === index}
-                onClick={() => handleCategoryClick(index)}
-                key={tab}
-              >
-                <ListItemText>{tab}</ListItemText>
-              </StyledListItem>
-            )
-          );
-        })}
-      </>
+export const ParticipantTabs = ({ handleClick, viewMode, stepIndex, collection }) => {
+  let steps;
+  if (collection === collectionType.NEW) {
+    steps = participantDetailStepNames.filter(
+      (stepName) => !['Action Plan', 'Notes'].includes(stepName),
     );
-  }),
-);
+  } else {
+    steps = viewMode !== participantDetailViewModes.VIEW ? stepNames : participantDetailStepNames;
+  }
+
+  const handleCategoryClick = (clickedCategory) => {
+    handleClick(clickedCategory);
+  };
+
+  return (
+    <>
+      {steps.map((stepName) => {
+        const index = getStepIndexFromStepName(stepName);
+        return (
+          !!stepName && (
+            <StyledListItem
+              button
+              selected={stepIndex === index}
+              onClick={() => handleCategoryClick(index)}
+              key={stepName}
+            >
+              <ListItemText>{stepName}</ListItemText>
+            </StyledListItem>
+          )
+        );
+      })}
+    </>
+  );
+};

--- a/src/database/components/participantDetail/ParticipantDetailPage.js
+++ b/src/database/components/participantDetail/ParticipantDetailPage.js
@@ -13,7 +13,7 @@ import { ParticipantDetailView } from './ParticipantDetailView';
 import { DetailButton } from './DetailButton';
 import { participantStore, uiStore } from '../../../injectables';
 import { participantDetailViewModes, viewModes } from '../../../constants';
-import { participantDetailSteps } from '../../../fields';
+import { participantDetailSteps, getStepIndexFromStepName } from '../../../fields';
 import { AuthContext } from '../../../sign-in';
 import '../style/ParticipantDetailPage.css';
 
@@ -41,9 +41,6 @@ export const ParticipantDetailPage = inject(
       userID = !!currentUser.displayName ? currentUser.displayName : currentUser.email;
     }
     const stepsLength = participantDetailSteps.length;
-    const notesStep = stepsLength - 3;
-    const actionPlanStep = stepsLength - 2;
-    const historyStep = stepsLength - 1;
 
     /**
      * Steps the detail view back one step
@@ -69,11 +66,11 @@ export const ParticipantDetailPage = inject(
      * currentParticipantDetailView mode set in UIStore
      */
     const getParticipantDetailContents = () => {
-      if (currentParticipantDetailStep === notesStep) {
+      if (currentParticipantDetailStep === getStepIndexFromStepName('Notes')) {
         return <ParticipantDetailNotes user={userID} />;
-      } else if (currentParticipantDetailStep === actionPlanStep) {
+      } else if (currentParticipantDetailStep === getStepIndexFromStepName('Action Plan')) {
         return <ParticipantDetailActionPlan user={userID} />;
-      } else if (currentParticipantDetailStep === historyStep) {
+      } else if (currentParticipantDetailStep === getStepIndexFromStepName('History')) {
         return <ParticipantDetailHistory participant={currentParticipant} />;
       } else {
         if (currentParticipantDetailViewMode === participantDetailViewModes.EDIT) {

--- a/src/fields/fields.js
+++ b/src/fields/fields.js
@@ -1046,16 +1046,6 @@ export const initialValues = formSteps.reduce((values, step) => {
   return values;
 }, {});
 
-/**
- * Determines which step a field belongs to using its name and returns the step index
- * @param {string} fieldName
- * @return int step index
- */
-export const belongsToStepIndex = (fieldName) => {
-  const step = formSteps.find((step) => step.fields.find((field) => field.name === fieldName));
-  return formSteps.indexOf(step);
-};
-
 // lists of step names
 export const stepNames = formSteps.map((step) => step.stepName);
 export const participantDetailStepNames = participantDetailSteps.map((step) => step.stepName);
@@ -1068,3 +1058,23 @@ export const fieldNames = formSteps.reduce((values, step) => {
   });
   return values;
 }, {});
+
+/**
+ * Determines which step a field belongs to using its name and returns the step index
+ * @param {string} fieldName
+ * @return int step index
+ */
+export const belongsToStepIndex = (fieldName) => {
+  const step = formSteps.find((step) => step.fields.find((field) => field.name === fieldName));
+  return formSteps.indexOf(step);
+};
+
+/**
+ * Determines the index of a step to using its name
+ * @param {string} stepName
+ * @return int step index
+ */
+export const getStepIndexFromStepName = (stepName) => {
+  const step = participantDetailSteps.find(step => step.stepName === stepName);
+  return participantDetailSteps.indexOf(step);
+}


### PR DESCRIPTION
In this PR:
- Removed notes and action plan from the sidebar for new participants
- Changed getting the index of the notes, history, and action plan steps to be returned from a function rather than being hard-coded
- Made `ParticipantTabs` not an observer anymore